### PR TITLE
Improving performance by parsing flow output once

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,20 @@ $ npm i -D flowtype-loader
 In your webpack configuration
 
 ```js
+var FlowtypePlugin = require('flowtype-loader/plugin');
+
 module.exports = {
   // ...
   module: {
     preLoaders: [
       {test: /\.js$/, loader: "flowtype", exclude: /node_modules/}
     ]
-  }
+  },
+  plugins: [
+    new FlowtypePlugin()
+    // new FlowtypePlugin({cwd: '/path/'})
+    // new FlowtypePlugin({failOnError: true})
+  ]
   // ...
 }
 ```
-
-## TODO
-
-- [ ] Fix performance issue (parse flow output once)
-- [ ] Add option `failOnError`

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,4 +1,6 @@
 var path = require('path');
+var FlowtypePlugin = require('../plugin');
+
 module.exports = {
 	entry: './entry.js',
 	output: {
@@ -12,5 +14,8 @@ module.exports = {
 		loaders: [
 	    { test: /\.js$/, loader: 'babel' }
 	  ]
-	}
+	},
+	plugins: [
+		new FlowtypePlugin()
+	]
 };

--- a/index.js
+++ b/index.js
@@ -8,10 +8,15 @@ module.exports = function (source) {
   }
 
   var callback = this.async();
-  this.flowtypeCheck(this.resourcePath, function (errors) {
+  this.flowtypeCheck(this.resourcePath, function (errors, options) {
     var flowErrors = errors.map(prettyPrintError);
     if (flowErrors.length > 0) {
       flowErrors.map(this.emitError);
+      if (options.failOnError) {
+        throw new Error('Module failed because of a Flow error.\n'
+          + flowErrors.join('\n'));
+      }
+
     }
     callback(null, source);
   }.bind(this));

--- a/index.js
+++ b/index.js
@@ -1,38 +1,18 @@
-var execFile = require('child_process').execFile;
-var flow = require('flow-bin');
 var prettyPrintError = require('./lib/flowResult').prettyPrintError;
-var mainLocOfError = require('./lib/flowResult').mainLocOfError;
 
 module.exports = function (source) {
-  var loader = this;
-  // http://webpack.github.io/docs/how-to-write-a-loader.html#flag-itself-cacheable-if-possible
-  this.cacheable && this.cacheable();
-  var callback = this.async();
+  this.cacheable();
 
-  execFile(flow, ['status', '--json'], {
-    cwd: loader.context
-  },
-  function (err, res) {
-    if (err) {
-      // No .flowconfig found
-      if (err.code !==  12) {
-        try {
-          var json = JSON.parse(res);
-          if (!json.passed) {
-            json.errors
-              .filter(function (error) {
-                var mainLoc = mainLocOfError(error);
-                var mainFile = mainLoc && mainLoc.source;
-                return mainFile === loader.resourcePath;
-              })
-              .map(prettyPrintError)
-              .map(loader.emitError);
-          }
-        } catch (e) {
-          throw e;
-        }
-      }
+  if (typeof (this.flowtypeCheck) !== 'function') {
+    throw new Error('You need to configure FlowtypePlugin');
+  }
+
+  var callback = this.async();
+  this.flowtypeCheck(this.resourcePath, function (errors) {
+    var flowErrors = errors.map(prettyPrintError);
+    if (flowErrors.length > 0) {
+      flowErrors.map(this.emitError);
     }
     callback(null, source);
-  });
+  }.bind(this));
 };

--- a/lib/flowStatus.js
+++ b/lib/flowStatus.js
@@ -1,0 +1,29 @@
+var flowBin = require('flow-bin');
+var spawn = require('child_process').spawn;
+
+function flowStatus(cwd, callback) {
+  var flow = spawn(flowBin, ['status', '--json'], {cwd: cwd});
+  var flowJson = '';
+
+  flow.stdout.on('data', function (data) {
+    flowJson += data.toString();
+  });
+
+  flow.on('error', function(e) {
+    throw e;
+  });
+
+  flow.on('close', function (code) {
+    if (code !== 12 && flowJson !== '') {
+      try {
+        callback(JSON.parse(flowJson));
+      } catch (e) {
+        throw e;
+      }
+    } else {
+      callback(null);
+    }
+  });
+}
+
+module.exports = flowStatus;

--- a/plugin.js
+++ b/plugin.js
@@ -2,7 +2,10 @@ var flowStatus = require('./lib/flowStatus');
 var mainLocOfError = require('./lib/flowResult').mainLocOfError;
 
 function FlowtypePlugin(options) {
-  this._options = options || {cwd: process.cwd()};
+  this._options = options || {};
+  if (!this._options.cwd) {
+    this._options.cwd = process.cwd();
+  }
   this._resources = [];
   this._isFlowRunning = false;
   this._flowStatus = null;
@@ -53,7 +56,7 @@ FlowtypePlugin.prototype._notifyResourceError = function(resource) {
         return mainFile === resource.path;
       });
     }
-    resource.callback(errors);
+    resource.callback(errors, this._options);
   }
 };
 

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,77 @@
+var flowStatus = require('./lib/flowStatus');
+var mainLocOfError = require('./lib/flowResult').mainLocOfError;
+
+function FlowtypePlugin(options) {
+  this._options = options || {cwd: process.cwd()};
+  this._resources = [];
+  this._isFlowRunning = false;
+  this._flowStatus = null;
+}
+
+FlowtypePlugin.prototype.getFlowStatus = function () {
+  if (this._isFlowRunning) {
+    return true;
+  }
+
+  this._isFlowRunning = true;
+
+  flowStatus(this._options.cwd, function (status) {
+    this._flowStatus = status;
+    this._isFlowRunning = false;
+    this._notifyResources();
+  }.bind(this));
+};
+
+FlowtypePlugin.prototype.addResource = function (resourcePath, callback) {
+  var resource = {path: resourcePath, callback: callback};
+  if (this._isFlowRunning) {
+    this._resources.push(resource);
+  } else {
+    this._notifyResourceError(resource);
+  }
+};
+
+FlowtypePlugin.prototype.clearResources = function () {
+  this._resources = [];
+};
+
+FlowtypePlugin.prototype._notifyResources = function () {
+  for (var i = 0; i < this._resources.length; i++) {
+    var resource = this._resources[i];
+    this._notifyResourceError(resource);
+  }
+  this.clearResources();
+};
+
+FlowtypePlugin.prototype._notifyResourceError = function(resource) {
+  if (resource.callback) {
+    var errors = [];
+    if (this._flowStatus && !this._flowStatus.passed) {
+      errors = this._flowStatus.errors.filter(function (error) {
+        var mainLoc = mainLocOfError(error);
+        var mainFile = mainLoc && mainLoc.source;
+        return mainFile === resource.path;
+      });
+    }
+    resource.callback(errors);
+  }
+};
+
+FlowtypePlugin.prototype.apply = function (compiler) {
+  var plugin = this;
+
+  compiler.plugin('compile', function () {
+    plugin.clearResources();
+    plugin.getFlowStatus();
+  });
+
+  compiler.plugin('compilation', function (compilation) {
+    compilation.plugin('normal-module-loader', function (context, module) {
+      context.flowtypeCheck = function(resourcePath, callback) {
+        plugin.addResource(resourcePath, callback);
+      };
+    });
+  });
+};
+
+module.exports = FlowtypePlugin;


### PR DESCRIPTION
Here is a proposal of how to improve performance. I couldn't think in another implementation other than adding a plugin to handle Flow process. There are still some work to do (write tests, docs, etc). cc @torifat 
## Changes
- Added `flowStatus` function to handle `flow` process. Using `spawn` instead of `execFile`
  to handle larger outputs returned by Flow
- Added `FlowtypePlugin`, responsible for handling Flow output parsing
  and reporting resources errors
- Changed loader to use method injected by `FlowtypePlugin`
