### PR TITLE
Don't filter errors from downstream modules

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,5 +1,4 @@
 var flowStatus = require('./lib/flowStatus');
-var mainLocOfError = require('./lib/flowResult').mainLocOfError;
 
 function FlowtypePlugin(options) {
   this._options = options || {};

--- a/plugin.js
+++ b/plugin.js
@@ -50,11 +50,7 @@ FlowtypePlugin.prototype._notifyResourceError = function(resource) {
   if (resource.callback) {
     var errors = [];
     if (this._flowStatus && !this._flowStatus.passed) {
-      errors = this._flowStatus.errors.filter(function (error) {
-        var mainLoc = mainLocOfError(error);
-        var mainFile = mainLoc && mainLoc.source;
-        return mainFile === resource.path;
-      });
+      errors = this._flowStatus.errors
     }
     resource.callback(errors, this._options);
   }


### PR DESCRIPTION
Fixes #4 

cc/ @gabriel-laet @torifat 

---

This makes sure flow catches and throws errors when downstream modules are changed and cause type errors, instead of restricting it to only the file that was changed.

See an example of what this fixes in #4 

---

Does anyone think we should make this an option to FlowtypePlugin? I can't really see a case where you wouldn't want to catch these, but perhaps someone does have a use-case.