### PR TITLE
Update README to latest version of webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # flowtype-loader
-[Flow](https://flowtype.org/) loader for [webpack](https://webpack.github.io/)
+
+[Flow](https://flowtype.org/) loader for [webpack](https://webpack.js.org/)
 
 ## Install
 
@@ -15,7 +16,28 @@ $ npm i -D flowtype-loader
 
 ## Usage
 
-In your webpack configuration
+In your webpack `2.X` configuration:
+
+```js
+var FlowtypePlugin = require('flowtype-loader/plugin');
+
+module.exports = {
+  // ...
+  module: {
+    rules: [
+      {test: /\.js$/, loader: 'flowtype-loader', enforce: 'pre', exclude: /node_modules/},
+    ]
+  },
+  plugins: [
+    new FlowtypePlugin()
+    // new FlowtypePlugin({cwd: '/path/'})
+    // new FlowtypePlugin({failOnError: true})
+  ]
+  // ...
+}
+```
+
+If you are using webpack `1.x`:
 
 ```js
 var FlowtypePlugin = require('flowtype-loader/plugin');


### PR DESCRIPTION
I just installed this loader in a project I'm working on. I'm using webpack 2
and there are no `preLoaders` now as explained
[here](https://webpack.js.org/guides/migrating/#module-preloaders-and-module-postloaders-was-removed).

I updated the documentation but kept the version one as I think it makes sense
to have both during the transition phase. Hope it helps!

Thank you for your time!