### PR TITLE
Bump webpack peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "webpack": "1 || ^2.1.0-beta"
+    "webpack": "1 || 2 || 3"
   },
   "devDependencies": {
     "babel-core": "^6.11.4",


### PR DESCRIPTION
Allow webpack v3. I've been using this on v2 and v3 without any issues, so it should be good to go, but let me know if you need any other changes!

Fixes #12