### PR TITLE
Remove webpack peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "plugin.js",
     "lib"
   ],
-  "peerDependencies": {
-    "webpack": "1 || 2 || 3"
-  },
   "devDependencies": {
     "babel-core": "^6.11.4",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
I came in to update the webpack peerDep to support v4, but I figure we can just remove it. It looks like even most of the webpack official loaders don't even put a peerDependency on webpack (I'm assuming bc there's not much else you can do with it).

What do you think?

This does work with webpack v4, btw, which was the initial change I went in to make.